### PR TITLE
Adjust input array for Big O test case

### DIFF
--- a/test/index-test.js
+++ b/test/index-test.js
@@ -40,9 +40,9 @@ describe('#largestSubarraySum', function() {
   });
 
   it('runs within the time limit - in O(n) time, instead of O(n^2) time', function () {
-    let timeLimit = 1000; // 1 seconds
+    const timeLimit = 1000; // 1 seconds
     this.timeout(timeLimit)
-    let array = new Array(1000).fill(1); // should result in sum of 10000
-    expect(largestSubarraySum(array)).toEqual(1000)
+    let array = new Array(10000).fill(1); // should result in sum of 10000
+    expect(largestSubarraySum(array)).toEqual(10000)
   });
 });


### PR DESCRIPTION
Increase number of elements in input array from 1000 to 10000.

Previously benchmarks showed that an input array of 1000 elements was
too small to make a simple nested for loop structure (that is to say, a
Big O(n ^2) time complexity) time out. The increase to 10000 not only
makes the test fail as intended, but gives padding to account for more
powerful machines running the tests inherently faster.

The previous code also shows a comment that seems to show the tests
were intended to equal 10000, which makes it seem as if 10000 was the
intended value all along.

#2 