### PR TITLE
Adjust test where all items are negative

### DIFF
--- a/test/index-test.js
+++ b/test/index-test.js
@@ -35,8 +35,8 @@ describe('#largestSubarraySum', function() {
 	})
 
   it('returns the largest subarray sum when all the items are negative', function() {
-		let array = [-1, -1, -5, -3, -7, -4, -5, -6, -100, -4]
-		expect(largestSubarraySum(array)).toEqual(0)
+		let array = [-7, -1, -5, -3, -7, -4, -5, -6, -100, -4]
+		expect(largestSubarraySum(array)).toEqual(-1)
   });
 
   it('runs within the time limit - in O(n) time, instead of O(n^2) time', function () {


### PR DESCRIPTION
Change the expected solution of the test when all items are negative to
equal the maximum element. In the case of the provided array, the answer
would be -1. This aligns with how the question is phrased, and is often
represented on algorithm sites.

Also change the input array so that the maximum element is a middle
element. This accounts for solutions that set the initial maximum to the
first element of the input array.

An alternate solution would be to change the wording of the problem to
only allow for sums above or equal to zero. 

#4 